### PR TITLE
Consider imported Go type lives in the same package if no mapping provided

### DIFF
--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -235,13 +235,14 @@ func refPathToGoType(refPath string, local bool) (string, error) {
 		return "", fmt.Errorf("unsupported reference: %s", refPath)
 	}
 	remoteComponent, flatComponent := pathParts[0], pathParts[1]
+	goType, err := refPathToGoType("#"+flatComponent, false)
+	if err != nil {
+		return "", err
+	}
 	if goImport, ok := importMapping[remoteComponent]; !ok {
-		return "", fmt.Errorf("unrecognized external reference '%s'; please provide the known import for this reference using option --import-mapping", remoteComponent)
+		// no import mapping provided, consider the go type is in the same package and doesn't need to be imported
+		return goType, nil
 	} else {
-		goType, err := refPathToGoType("#"+flatComponent, false)
-		if err != nil {
-			return "", err
-		}
 		return fmt.Sprintf("%s.%s", goImport.Name, goType), nil
 	}
 }

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -172,6 +172,11 @@ func TestRefPathToGoType(t *testing.T) {
 			goType: "externalRef0.Foo",
 		},
 		{
+			name:   "remote-no-mapping-provided",
+			path:   "nomapping.json#/foo",
+			goType: "Foo",
+		},
+		{
 			name:   "url-root",
 			path:   "http://deepmap.com/doc.json#/foo_bar",
 			goType: "externalRef1.FooBar",


### PR DESCRIPTION
This commit allows referencing imported types living in the same go package.
We consider no import is necessary if no import mapping is provided for the
remote reference, and reference the go type by its name (no import path).

Downside of this approach: no error is returned if the user accidentally forget
or messes up the import mapping. Code compilation will likely fail instead.

Fixes https://github.com/deepmap/oapi-codegen/issues/400.